### PR TITLE
Add Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,13 @@ language: ruby
 rvm:
  - 2.2
 
-before_install:
- - gem install bundler
+services:
+  - docker
 
-script: bundle exec rspec
+before_install:
+  - gem install bundler
+  - docker build -t gitlabci-cli .
+
+script:
+  - bundle exec rspec
+  - docker run gitlabci-cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update -qq && \
     apt-get install -qq -y \
       build-essential \
       bundler \
+      git-core \
       ruby \
       ruby-dev \
       rubygems && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM rockyluke/debian:jessie
+FROM debian:jessie
 
 ENV DEBIAN_FRONTEND=noninteractive \
     TZ=Europe/Amsterdam
@@ -25,7 +25,8 @@ RUN apt-get update -qq && \
       ruby \
       ruby-dev \
       rubygems && \
-    apt-clean
+    apt-get autoclean && \
+    apt-get autoremove
 
 RUN git clone https://github.com/wdhif/gitlabci-cli.git /usr/src && \
     cd /usr/src && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# Copyright (c) 2017 rockyluke
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM rockyluke/debian:jessie
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    TZ=Europe/Amsterdam
+
+RUN apt-get update -qq && \
+    apt-get upgrade -qq -y && \
+    apt-get install -qq -y \
+      build-essential \
+      bundler \
+      ruby \
+      ruby-dev \
+      rubygems && \
+    apt-clean
+
+RUN git clone https://github.com/wdhif/gitlabci-cli.git /usr/src && \
+    cd /usr/src && \
+    bundle install
+
+WORKDIR /usr/src
+
+ENTRYPOINT [ "bundle", "exec", "gitlabci-cli" ]
+
+CMD [ "help" ]
+# EOF


### PR DESCRIPTION
It's simply working like : 

$ docker build -t gitlabci-cli .

$ docker run gitlabci-cli help
Commands:
  gitlabci-cli help [COMMAND]       # Describe available commands or one spec...
  gitlabci-cli pipeline SUBCOMMAND  # Interact the pipeline API
  gitlabci-cli trigger SUBCOMMAND   # Interact the trigger API

$ docker run gitlabci-cli help pipeline
Commands:
  gitlabci-cli pipeline cancel -i, --id=ID -p, --pipeline=PIPELINE -t, --toke...
  gitlabci-cli pipeline get -i, --id=ID -p, --pipeline=PIPELINE -t, --token=T...
  gitlabci-cli pipeline help [COMMAND]                                       ...
  gitlabci-cli pipeline list -i, --id=ID -t, --token=TOKEN -u, --url=URL     ...
  gitlabci-cli pipeline retry -i, --id=ID -p, --pipeline=PIPELINE -t, --token...
  gitlabci-cli pipeline run -i, --id=ID -t, --token=TOKEN -u, --url=URL      ...